### PR TITLE
Completes ncnews-8: GET /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -69,10 +69,10 @@ describe('Errors: Invalid PATCH requests: vote increment / decrements via /api/a
   });
   it("400: Responds with 'Votes property must be a number' if inc_votes not a number, ", () => {
     const identifier = 3;
-    const votesIsNaN = 'notNum';
+    const votesIsAString = 'notNum';
     return request(app)
       .patch(`/api/articles/1`)
-      .send({ inc_votes: votesIsNaN })
+      .send({ inc_votes: votesIsAString })
       .expect(400)
       .then((res) => {
         expect(res.body.msg).toBe('Votes property must be a number');
@@ -199,6 +199,47 @@ describe('Success path: GET requests for users: /api/users', () => {
         });
         expect(res.body.users[3]).toEqual({
           username: 'lurker',
+        });
+      });
+  });
+});
+
+describe('Success path: GET /api/articles', () => {
+  test('200: Responds with array of article objects, including author, title, article_id, topic, created_at (sorted desc), votes, comment_count', () => {
+    return request(app)
+      .get('/api/articles')
+      .expect(200)
+      .then((res) => {
+        expect(res.body.articles).toBeInstanceOf(Array);
+        expect(res.body.articles.length).toBe(12);
+        res.body.articles.forEach((article) => {
+          expect(article).toMatchObject({
+            author: expect.any(String),
+            title: expect.any(String),
+            article_id: expect.any(Number),
+            topic: expect.any(String),
+            created_at: expect.any(String),
+            votes: expect.any(Number),
+            comment_count: expect.any(String),
+          });
+        });
+        expect(res.body.articles[4]).toEqual({
+          author: 'rogersop',
+          title: 'UNCOVERED: catspiracy to bring down democracy',
+          article_id: 5,
+          topic: 'cats',
+          created_at: '2020-08-03T13:14:00.000Z',
+          votes: 0,
+          comment_count: '2',
+        });
+        expect(res.body.articles[10]).toEqual({
+          author: 'icellusedkars',
+          title: 'Am I a cat?',
+          article_id: 11,
+          topic: 'mitch',
+          created_at: '2020-01-15T22:21:00.000Z',
+          votes: 0,
+          comment_count: '0',
         });
       });
   });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -3,6 +3,7 @@ const request = require('supertest');
 const db = require('../db/connection');
 const seed = require('../db/seeds/seed');
 const testData = require('../db/data/test-data');
+const jestSorted = require('jest-sorted');
 
 afterAll(() => db.end());
 beforeEach(() => seed(testData));
@@ -212,6 +213,9 @@ describe('Success path: GET /api/articles', () => {
       .then((res) => {
         expect(res.body.articles).toBeInstanceOf(Array);
         expect(res.body.articles.length).toBe(12);
+        expect(res.body.articles).toBeSortedBy('created_at', {
+          descending: true,
+        });
         res.body.articles.forEach((article) => {
           expect(article).toMatchObject({
             author: expect.any(String),

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const { getTopics } = require('./controllers/topics.controllers');
 const {
   getArticleById,
   patchArticleVotesById,
+  getArticles,
 } = require('./controllers/articles.controllers');
 
 const { getUsers } = require('./controllers/users.controllers');
@@ -14,6 +15,7 @@ app.use(express.json());
 // Get Methods
 app.get('/api/topics', getTopics);
 app.get('/api/articles/:article_id', getArticleById);
+app.get('/api/articles', getArticles);
 app.get('/api/users', getUsers);
 
 // Patch Methods

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,6 +1,7 @@
 const {
   selectArticleById,
   updateArticleVotesById,
+  selectArticles,
 } = require('../models/articles.models');
 
 exports.getArticleById = (req, res, next) => {
@@ -8,6 +9,14 @@ exports.getArticleById = (req, res, next) => {
   selectArticleById(article_id)
     .then((article) => {
       res.status(200).send({ article });
+    })
+    .catch((err) => next(err));
+};
+
+exports.getArticles = (req, res, next) => {
+  selectArticles()
+    .then((articles) => {
+      res.status(200).send({ articles });
     })
     .catch((err) => next(err));
 };

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,6 +1,7 @@
 const db = require('../db/connection');
 const format = require('pg-format');
 
+// SELECT models
 exports.selectArticleById = (article_id) => {
   const query = `SELECT u.username as author, a.title,a.article_id, a.body,a.topic,a.created_at, a.votes, COUNT(c.article_id) as comment_count
     FROM articles a
@@ -19,6 +20,24 @@ exports.selectArticleById = (article_id) => {
   });
 };
 
+exports.selectArticles = () => {
+  const query = `SELECT u.username as author, a.title,a.article_id, a.topic,a.created_at, a.votes, COUNT(c.article_id) as comment_count
+  FROM articles a
+  INNER JOIN  users u
+  ON a.author = u.username
+  LEFT JOIN comments c
+  on a.article_id = c.article_id
+  GROUP BY u.username, a.title,a.article_id, a.topic,a.created_at, a.votes
+  ORDER BY a.created_at DESC;`;
+  return db.query(query).then((res) => {
+    if (!res.rows.length) {
+      return Promise.reject({ msg: 'No articles found', status: 404 });
+    }
+    return res.rows;
+  });
+};
+
+// UPDATE models
 exports.updateArticleVotesById = (article_id, inc_votes) => {
   const query = `UPDATE articles
   SET votes = votes + $1

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "husky": "^7.0.0",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.14",
         "nodemon": "^2.0.15",
         "pg-format": "^1.0.4",
         "supertest": "^6.2.2"
@@ -3615,6 +3616,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -8608,6 +8615,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "husky": "^7.0.0",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.14",
     "nodemon": "^2.0.15",
     "pg-format": "^1.0.4",
     "supertest": "^6.2.2"


### PR DESCRIPTION
***ADDED***
app.get('/api/articles', getArticles)
articles.models - selectArticles
articles.controllers - getArticles
Tests for valid 200 responses where an articles have, or have not got comments, with examples

***CHANGED***
No further changes

***UPDATED***
Changed variable name 'votesIsNan' to 'votesIsAString' in test '400: Responds with 'Votes property must be a number' if inc_votes not a number', per ncnews-4 review by @giteron: 'The wording may suggest it holds either a boolean, or a literal NaN (which is a typeof number), whereas currently it holds a string'

ADDENDUM: Updated /api/topics test to use jest-sorted to verify articles are returned in descending created_at date order, see https://github.com/garetheverson/back-end-news-portfolio-project/pull/7/commits/41e2e01d725d11aca481dba836eac1811d290b03