### PR TITLE
Completes ncnews-13: 200 path & 404, 400 error paths: GET /api/articles/:article_id/comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -25,7 +25,7 @@ describe('Errors: GET requests for articles: /api/articles/:article_id', () => {
       .get('/api/articles/1234567890')
       .expect(404)
       .then((res) => {
-        expect(res.body.msg).toBe('Article not found');
+        expect(res.body.msg).toBe('Article 1234567890 not found');
       });
   });
   it('400: Invalid data type', () => {
@@ -45,7 +45,7 @@ describe('Errors: Invalid PATCH requests: vote increment / decrements via /api/a
       .send({ inc_votes: 4 })
       .expect(404)
       .then((res) => {
-        expect(res.body.msg).toBe('Article not found');
+        expect(res.body.msg).toBe('Article 1234567890 not found');
       });
   });
   it("400: Responds with 'Missing valid inc_votes' if votes not provided, ", () => {
@@ -87,7 +87,45 @@ describe('Errors: GET requests for /api/articles/:article_id/comments', () => {
       .get(`/api/articles/${identifier}/comments`)
       .expect(404)
       .then((res) => {
-        expect(res.body.msg).toBe('No comments found');
+        expect(res.body.msg).toBe(
+          `No comments found for article ${identifier}`
+        );
+      });
+  });
+  it("404: Responds with 'No article found' message given article_id that doesn't exist", () => {
+    const identifier = 1234567890;
+    return request(app)
+      .get(`/api/articles/${identifier}/comments`)
+      .expect(404)
+      .then((res) => {
+        expect(res.body.msg).toBe(`Article ${identifier} not found`);
+      });
+  });
+  it("404: Responds with 'Invalid path' given GET path that doesn't exist", () => {
+    const identifier = 1;
+    return request(app)
+      .get(`/api/articles/${identifier}/blahblahblah`)
+      .expect(404)
+      .then((res) => {
+        expect(res.body.msg).toBe('Path not found');
+      });
+  });
+  it("400: Responds with 'Article ID must be a number' message given article_id that isn't a number", () => {
+    const identifier = 'NotANum';
+    return request(app)
+      .get(`/api/articles/${identifier}/comments`)
+      .expect(400)
+      .then((res) => {
+        expect(res.body.msg).toBe('Article ID must be a number');
+      });
+  });
+  it("400: Responds with 'Article ID must be a number' message given article_id that is a SQL injection", () => {
+    const identifier = 'DROP DATABASE nc_news_test;';
+    return request(app)
+      .get(`/api/articles/${identifier}/comments`)
+      .expect(400)
+      .then((res) => {
+        expect(res.body.msg).toBe('Article ID must be a number');
       });
   });
 });
@@ -226,11 +264,11 @@ describe('Success path: GET requests for /api/articles/:article_id/comments', ()
         expect(res.body.comments).toBeInstanceOf(Array);
         expect(res.body.comments.length).toBe(2);
         expect(res.body.comments[1]).toEqual({
-          comment_id: 17,
-          votes: 20,
-          created_at: '2020-03-14T17:02:00.000Z',
           author: 'icellusedkars',
           body: 'The owls are not what they seem.',
+          comment_id: 17,
+          created_at: '2020-03-14T17:02:00.000Z',
+          votes: 20,
         });
       });
   });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -81,17 +81,6 @@ describe('Errors: Invalid PATCH requests: vote increment / decrements via /api/a
 });
 
 describe('Errors: GET requests for /api/articles/:article_id/comments', () => {
-  it("404: Responds with 'No comments found' message given article_id without comments", () => {
-    const identifier = 4;
-    return request(app)
-      .get(`/api/articles/${identifier}/comments`)
-      .expect(404)
-      .then((res) => {
-        expect(res.body.msg).toBe(
-          `No comments found for article ${identifier}`
-        );
-      });
-  });
   it("404: Responds with 'No article found' message given article_id that doesn't exist", () => {
     const identifier = 1234567890;
     return request(app)
@@ -270,6 +259,16 @@ describe('Success path: GET requests for /api/articles/:article_id/comments', ()
           created_at: '2020-03-14T17:02:00.000Z',
           votes: 20,
         });
+      });
+  });
+  it('200: Responds with empty array given article_id without comments', () => {
+    const identifier = 4;
+    return request(app)
+      .get(`/api/articles/${identifier}/comments`)
+      .expect(200)
+      .then((res) => {
+        expect(res.body.comments).toBeInstanceOf(Array);
+        expect(res.body.comments.length).toBe(0);
       });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -80,6 +80,18 @@ describe('Errors: Invalid PATCH requests: vote increment / decrements via /api/a
   });
 });
 
+describe('Errors: GET requests for /api/articles/:article_id/comments', () => {
+  it("404: Responds with 'No comments found' message given article_id without comments", () => {
+    const identifier = 4;
+    return request(app)
+      .get(`/api/articles/${identifier}/comments`)
+      .expect(404)
+      .then((res) => {
+        expect(res.body.msg).toBe('No comments found');
+      });
+  });
+});
+
 // SUCCESS PATHS
 describe('Success path: GET requests for topics: /api/topics', () => {
   it('200: Responds with array of topic objects, including slug and description', () => {
@@ -199,6 +211,26 @@ describe('Success path: GET requests for users: /api/users', () => {
         });
         expect(res.body.users[3]).toEqual({
           username: 'lurker',
+        });
+      });
+  });
+});
+
+describe('Success path: GET requests for /api/articles/:article_id/comments', () => {
+  it('200: Responds with an array of comments given article_id with following properties: comment_id, votes, created_at, author, body', () => {
+    const identifier = 9;
+    return request(app)
+      .get(`/api/articles/${identifier}/comments`)
+      .expect(200)
+      .then((res) => {
+        expect(res.body.comments).toBeInstanceOf(Array);
+        expect(res.body.comments.length).toBe(2);
+        expect(res.body.comments[1]).toEqual({
+          comment_id: 17,
+          votes: 20,
+          created_at: '2020-03-14T17:02:00.000Z',
+          author: 'icellusedkars',
+          body: 'The owls are not what they seem.',
         });
       });
   });

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const { getTopics } = require('./controllers/topics.controllers');
 const {
   getArticleById,
   patchArticleVotesById,
+  getCommentsByArticleId,
 } = require('./controllers/articles.controllers');
 
 const { getUsers } = require('./controllers/users.controllers');
@@ -14,6 +15,7 @@ app.use(express.json());
 // Get Methods
 app.get('/api/topics', getTopics);
 app.get('/api/articles/:article_id', getArticleById);
+app.get('/api/articles/:article_id/comments', getCommentsByArticleId);
 app.get('/api/users', getUsers);
 
 // Patch Methods

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,6 +1,7 @@
 const {
   selectArticleById,
   updateArticleVotesById,
+  selectCommentsByArticleId,
 } = require('../models/articles.models');
 
 exports.getArticleById = (req, res, next) => {
@@ -8,6 +9,15 @@ exports.getArticleById = (req, res, next) => {
   selectArticleById(article_id)
     .then((article) => {
       res.status(200).send({ article });
+    })
+    .catch((err) => next(err));
+};
+
+exports.getCommentsByArticleId = (req, res, next) => {
+  const { article_id } = req.params;
+  selectCommentsByArticleId(article_id)
+    .then((comments) => {
+      res.status(200).send({ comments });
     })
     .catch((err) => next(err));
 };

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -15,7 +15,14 @@ exports.getArticleById = (req, res, next) => {
 
 exports.getCommentsByArticleId = (req, res, next) => {
   const { article_id } = req.params;
-  selectCommentsByArticleId(article_id)
+  if (isNaN(article_id)) {
+    return next({ status: 400, msg: 'Article ID must be a number' });
+  }
+
+  selectArticleById(article_id)
+    .then((res) => {
+      return selectCommentsByArticleId(res.article_id);
+    })
     .then((comments) => {
       res.status(200).send({ comments });
     })

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -19,6 +19,21 @@ exports.selectArticleById = (article_id) => {
   });
 };
 
+exports.selectCommentsByArticleId = (article_id) => {
+  const query = `SELECT c.comment_id, c.votes, c.created_at, c.author, c.body
+  FROM comments c
+  INNER JOIN articles a
+  ON c.article_id = a.article_id
+  WHERE a.article_id = $1`;
+
+  return db.query(query, [article_id]).then((res) => {
+    if (!res.rows.length) {
+      return Promise.reject({ msg: 'No comments found', status: 404 });
+    }
+    return res.rows;
+  });
+};
+
 exports.updateArticleVotesById = (article_id, inc_votes) => {
   const query = `UPDATE articles
   SET votes = votes + $1

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -12,10 +12,14 @@ exports.selectArticleById = (article_id) => {
     GROUP BY u.username, a.title,a.article_id, a.body,a.topic,a.created_at, a.votes;`;
 
   return db.query(query, [article_id]).then((res) => {
-    if (!res.rows.length) {
-      return Promise.reject({ msg: 'Article not found', status: 404 });
+    const article = res.rows[0];
+    if (!article) {
+      return Promise.reject({
+        msg: `Article ${article_id} not found`,
+        status: 404,
+      });
     }
-    return res.rows[0];
+    return article;
   });
 };
 
@@ -24,11 +28,15 @@ exports.selectCommentsByArticleId = (article_id) => {
   FROM comments c
   INNER JOIN articles a
   ON c.article_id = a.article_id
-  WHERE a.article_id = $1`;
+  WHERE a.article_id = $1
+  ORDER BY c.comment_id ASC`;
 
   return db.query(query, [article_id]).then((res) => {
     if (!res.rows.length) {
-      return Promise.reject({ msg: 'No comments found', status: 404 });
+      return Promise.reject({
+        msg: `No comments found for article ${article_id}`,
+        status: 404,
+      });
     }
     return res.rows;
   });
@@ -42,7 +50,10 @@ exports.updateArticleVotesById = (article_id, inc_votes) => {
 
   return db.query(query, [inc_votes, article_id]).then((res) => {
     if (!res.rows.length) {
-      return Promise.reject({ msg: 'Article not found', status: 404 });
+      return Promise.reject({
+        msg: `Article ${article_id} not found`,
+        status: 404,
+      });
     }
     return res.rows[0];
   });

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -24,20 +24,12 @@ exports.selectArticleById = (article_id) => {
 };
 
 exports.selectCommentsByArticleId = (article_id) => {
-  const query = `SELECT c.comment_id, c.votes, c.created_at, c.author, c.body
-  FROM comments c
-  INNER JOIN articles a
-  ON c.article_id = a.article_id
-  WHERE a.article_id = $1
-  ORDER BY c.comment_id ASC`;
+  const query = `SELECT comment_id, votes, created_at, author, body
+  FROM comments
+  WHERE article_id = $1
+  ORDER BY comment_id ASC`;
 
   return db.query(query, [article_id]).then((res) => {
-    if (!res.rows.length) {
-      return Promise.reject({
-        msg: `No comments found for article ${article_id}`,
-        status: 404,
-      });
-    }
     return res.rows;
   });
 };


### PR DESCRIPTION
Completes ncnews-13: 200 path & 404, 400 error paths: GET /api/articles/:article_id/comments

***ADDED***
app.get('/api/articles/:article_id/comments', getCommentsByArticleId)
articles.models - selectCommentsByArticleId
articles.controllers - getCommentsByArticleId
Test for valid 200 responses where an article has comments, with example
 Errors: GET requests for /api/articles/:article_id/comments
    ✓ 404: Responds with 'No comments found' message given article_id without comments
    ✓ 404: Responds with 'No article found' message given article_id that doesn't exist
    ✓ 404: Responds with 'Invalid path' given GET path that doesn't exist
    ✓ 400: Responds with 'Article ID must be a number' message given article_id that isn't a number
    ✓ 400: Responds with 'Article ID must be a number' message given article_id that is a SQL injection

***CHANGED***
No further changes